### PR TITLE
Bug: DataverseBase Class not in core of easyDataverse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+# VS Code
+.vscode/

--- a/pyDaRUS/metadatablocks/archive.py
+++ b/pyDaRUS/metadatablocks/archive.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 

--- a/pyDaRUS/metadatablocks/astrophysics.py
+++ b/pyDaRUS/metadatablocks/astrophysics.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional, Union
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -239,7 +239,6 @@ class Astrophysics(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'astrophysics'
 
-
     def add_dataset_date_range(
         self,
         start: Optional[str] = None,
@@ -248,18 +247,13 @@ class Astrophysics(DataverseBase):
         """Function used to add an instance of DatasetDateRange to the metadatablock.
 
         Args:
-        
+
             start (string): Dataset Start Date
             end (string): Dataset End Date
 
         """
 
-        self.dataset_date_range.append(
-            DatasetDateRange(
-                start=start, end=end
-            )
-        )
-
+        self.dataset_date_range.append(DatasetDateRange(start=start, end=end))
 
     def add_redshift_value(
         self,
@@ -269,18 +263,13 @@ class Astrophysics(DataverseBase):
         """Function used to add an instance of RedshiftValue to the metadatablock.
 
         Args:
-        
+
             minimum (number): The minimum value of the redshift (unitless) or Doppler velocity (km/s in the data object.
             maximum (number): The maximum value of the redshift (unitless) or Doppler velocity (km/s in the data object.
 
         """
 
-        self.redshift_value.append(
-            RedshiftValue(
-                minimum=minimum, maximum=maximum
-            )
-        )
-
+        self.redshift_value.append(RedshiftValue(minimum=minimum, maximum=maximum))
 
     def add_wavelength_range(
         self,
@@ -290,14 +279,10 @@ class Astrophysics(DataverseBase):
         """Function used to add an instance of WavelengthRange to the metadatablock.
 
         Args:
-        
+
             minimum_(m) (number): The minimum wavelength of the spectral bandpass, in meters.
             maximum_(m) (number): The maximum wavelength of the spectral bandpass, in meters.
 
         """
 
-        self.wavelength_range.append(
-            WavelengthRange(
-                extra_data=extra_data
-            )
-        )
+        self.wavelength_range.append(WavelengthRange(extra_data=extra_data))

--- a/pyDaRUS/metadatablocks/biomedical.py
+++ b/pyDaRUS/metadatablocks/biomedical.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional, Union
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 

--- a/pyDaRUS/metadatablocks/citation.py
+++ b/pyDaRUS/metadatablocks/citation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional, Union
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -949,7 +949,6 @@ class Citation(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'citation'
 
-
     def add_author(
         self,
         name: Optional[str] = None,
@@ -960,7 +959,7 @@ class Citation(DataverseBase):
         """Function used to add an instance of Author to the metadatablock.
 
         Args:
-        
+
             name (string): The author's Family Name, Given Name or the name of the organization responsible for this Dataset.
             affiliation (string): The organization with which the author is affiliated.
             identifier_scheme (Enum): Name of the identifier scheme (ORCID, ISNI).
@@ -970,10 +969,12 @@ class Citation(DataverseBase):
 
         self.author.append(
             Author(
-                name=name, affiliation=affiliation, identifier_scheme=identifier_scheme, identifier=identifier
+                name=name,
+                affiliation=affiliation,
+                identifier_scheme=identifier_scheme,
+                identifier=identifier,
             )
         )
-
 
     def add_contact(
         self,
@@ -984,19 +985,14 @@ class Citation(DataverseBase):
         """Function used to add an instance of Contact to the metadatablock.
 
         Args:
-        
+
             name (string): The contact's Family Name, Given Name or the name of the organization.
             affiliation (string): The organization with which the contact is affiliated.
             email (string): The e-mail address(es) of the contact(s) for the Dataset. This will not be displayed.
 
         """
 
-        self.contact.append(
-            Contact(
-                name=name, affiliation=affiliation, email=email
-            )
-        )
-
+        self.contact.append(Contact(name=name, affiliation=affiliation, email=email))
 
     def add_contributor(
         self,
@@ -1006,18 +1002,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of Contributor to the metadatablock.
 
         Args:
-        
-            type (Enum): The type of contributor of the  resource.  
+
+            type (Enum): The type of contributor of the  resource.
             name (string): The Family Name, Given Name or organization name of the contributor.
 
         """
 
-        self.contributor.append(
-            Contributor(
-                type=type, name=name
-            )
-        )
-
+        self.contributor.append(Contributor(type=type, name=name))
 
     def add_date_of_collection(
         self,
@@ -1027,18 +1018,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of DateOfCollection to the metadatablock.
 
         Args:
-        
+
             start (string): Date when the data collection started.
             end (string): Date when the data collection ended.
 
         """
 
-        self.date_of_collection.append(
-            DateOfCollection(
-                start=start, end=end
-            )
-        )
-
+        self.date_of_collection.append(DateOfCollection(start=start, end=end))
 
     def add_description(
         self,
@@ -1048,18 +1034,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of Description to the metadatablock.
 
         Args:
-        
+
             text (string): A summary describing the purpose, nature, and scope of the Dataset.
             date (string): In cases where a Dataset contains more than one description (for example, one might be supplied by the data producer and another prepared by the data repository where the data are deposited), the date attribute is used to distinguish between the two descriptions. The date attribute follows the ISO convention of YYYY-MM-DD.
 
         """
 
-        self.description.append(
-            Description(
-                text=text, date=date
-            )
-        )
-
+        self.description.append(Description(text=text, date=date))
 
     def add_distributor(
         self,
@@ -1072,7 +1053,7 @@ class Citation(DataverseBase):
         """Function used to add an instance of Distributor to the metadatablock.
 
         Args:
-        
+
             name (string): Distributor name
             affiliation (string): The organization with which the distributor contact is affiliated.
             abbreviation (string): The abbreviation by which this distributor is commonly known (e.g., IQSS, ICPSR).
@@ -1083,10 +1064,13 @@ class Citation(DataverseBase):
 
         self.distributor.append(
             Distributor(
-                name=name, affiliation=affiliation, abbreviation=abbreviation, url=url, logo_url=logo_url
+                name=name,
+                affiliation=affiliation,
+                abbreviation=abbreviation,
+                url=url,
+                logo_url=logo_url,
             )
         )
-
 
     def add_grant_information(
         self,
@@ -1096,18 +1080,15 @@ class Citation(DataverseBase):
         """Function used to add an instance of GrantInformation to the metadatablock.
 
         Args:
-        
+
             grant_agency (string): Grant Number Agency
             grant_number (string): The grant or contract number of the project that  sponsored the effort.
 
         """
 
         self.grant_information.append(
-            GrantInformation(
-                grant_agency=grant_agency, grant_number=grant_number
-            )
+            GrantInformation(grant_agency=grant_agency, grant_number=grant_number)
         )
-
 
     def add_keyword(
         self,
@@ -1118,7 +1099,7 @@ class Citation(DataverseBase):
         """Function used to add an instance of Keyword to the metadatablock.
 
         Args:
-        
+
             term (string): Key terms that describe important aspects of the Dataset. Can be used for building keyword indexes and for classification and retrieval purposes. A controlled vocabulary can be employed. The vocab attribute is provided for specification of the controlled vocabulary in use, such as LCSH, MeSH, or others. The vocabURI attribute specifies the location for the full controlled vocabulary.
             vocabulary (string): For the specification of the keyword controlled vocabulary in use, such as LCSH, MeSH, or others.
             vocabulary_url (string): Keyword vocabulary URL points to the web presence that describes the keyword vocabulary, if appropriate. Enter an absolute URL where the keyword vocabulary web site is found, such as http://www.my.org.
@@ -1126,11 +1107,8 @@ class Citation(DataverseBase):
         """
 
         self.keyword.append(
-            Keyword(
-                term=term, vocabulary=vocabulary, vocabulary_url=vocabulary_url
-            )
+            Keyword(term=term, vocabulary=vocabulary, vocabulary_url=vocabulary_url)
         )
-
 
     def add_other_id(
         self,
@@ -1140,18 +1118,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of OtherId to the metadatablock.
 
         Args:
-        
+
             agency (string): Name of agency which generated this identifier.
             identifier (string): Other identifier that corresponds to this Dataset.
 
         """
 
-        self.other_id.append(
-            OtherId(
-                agency=agency, identifier=identifier
-            )
-        )
-
+        self.other_id.append(OtherId(agency=agency, identifier=identifier))
 
     def add_producer(
         self,
@@ -1164,21 +1137,24 @@ class Citation(DataverseBase):
         """Function used to add an instance of Producer to the metadatablock.
 
         Args:
-        
+
             name (string): Producer name
             affiliation (string): The organization with which the producer is affiliated.
             abbreviation (string): The abbreviation by which the producer is commonly known. (ex. IQSS, ICPSR)
-            url (string): Producer URL points to the producer's web presence, if appropriate. Enter an absolute URL where the producer's web site is found, such as http://www.my.org.  
+            url (string): Producer URL points to the producer's web presence, if appropriate. Enter an absolute URL where the producer's web site is found, such as http://www.my.org.
             logo_url (string): URL for the producer's logo, which points to this  producer's web-accessible logo image. Enter an absolute URL where the producer's logo image is found, such as http://www.my.org/images/logo.gif.
 
         """
 
         self.producer.append(
             Producer(
-                name=name, affiliation=affiliation, abbreviation=abbreviation, url=url, logo_url=logo_url
+                name=name,
+                affiliation=affiliation,
+                abbreviation=abbreviation,
+                url=url,
+                logo_url=logo_url,
             )
         )
-
 
     def add_project(
         self,
@@ -1188,18 +1164,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of Project to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the project.
             level (integer): The main project should get level zero. Subprojects can get higher levels.
 
         """
 
-        self.project.append(
-            Project(
-                name=name, level=level
-            )
-        )
-
+        self.project.append(Project(name=name, level=level))
 
     def add_related_publication(
         self,
@@ -1211,7 +1182,7 @@ class Citation(DataverseBase):
         """Function used to add an instance of RelatedPublication to the metadatablock.
 
         Args:
-        
+
             citation (string): The full bibliographic citation for this related publication.
             id_type (Enum): The type of digital identifier used for this publication (e.g., Digital Object Identifier (DOI)).
             id_number (string): The identifier for the selected ID type.
@@ -1225,7 +1196,6 @@ class Citation(DataverseBase):
             )
         )
 
-
     def add_series(
         self,
         name: Optional[str] = None,
@@ -1234,18 +1204,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of Series to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the dataset series to which the Dataset belongs.
             information (string): History of the series and summary of those features that apply to the series as a whole.
 
         """
 
-        self.series.append(
-            Series(
-                name=name, information=information
-            )
-        )
-
+        self.series.append(Series(name=name, information=information))
 
     def add_software(
         self,
@@ -1255,18 +1220,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of Software to the metadatablock.
 
         Args:
-        
+
             name (string): Name of software used to generate the Dataset.
             version (string): Version of the software used to generate the Dataset.
 
         """
 
-        self.software.append(
-            Software(
-                name=name, version=version
-            )
-        )
-
+        self.software.append(Software(name=name, version=version))
 
     def add_storage(
         self,
@@ -1277,19 +1237,14 @@ class Citation(DataverseBase):
         """Function used to add an instance of Storage to the metadatablock.
 
         Args:
-        
+
             name (string): The name of the file, directory or archive.
-            location (string): The dns, path or url of the location the object is stored. 
+            location (string): The dns, path or url of the location the object is stored.
             size (string): The approximated size of the object. Give also Units.
 
         """
 
-        self.storage.append(
-            Storage(
-                name=name, location=location, size=size
-            )
-        )
-
+        self.storage.append(Storage(name=name, location=location, size=size))
 
     def add_time_period_covered(
         self,
@@ -1299,18 +1254,13 @@ class Citation(DataverseBase):
         """Function used to add an instance of TimePeriodCovered to the metadatablock.
 
         Args:
-        
+
             start (string): Start date which reflects the time period covered by the data, not the dates of coding or making documents machine-readable or the dates the data were collected.
             end (string): End date which reflects the time period covered by the data, not the dates of coding or making documents machine-readable or the dates the data were collected.
 
         """
 
-        self.time_period_covered.append(
-            TimePeriodCovered(
-                start=start, end=end
-            )
-        )
-
+        self.time_period_covered.append(TimePeriodCovered(start=start, end=end))
 
     def add_topic_classification(
         self,
@@ -1321,7 +1271,7 @@ class Citation(DataverseBase):
         """Function used to add an instance of TopicClassification to the metadatablock.
 
         Args:
-        
+
             term (string): Topic or Subject term that is relevant to this Dataset.
             vocabulary (string): Provided for specification of the controlled vocabulary in use, e.g., LCSH, MeSH, etc.
             vocabulary_url (string): Specifies the URL location for the full controlled vocabulary.

--- a/pyDaRUS/metadatablocks/codeMeta.py
+++ b/pyDaRUS/metadatablocks/codeMeta.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -203,7 +203,6 @@ class CodeMeta(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'codeMeta'
 
-
     def add_software_requirements(
         self,
         name: Optional[str] = None,
@@ -212,18 +211,13 @@ class CodeMeta(DataverseBase):
         """Function used to add an instance of SoftwareRequirements to the metadatablock.
 
         Args:
-        
+
             name (string): Name or title of the required software/library
             url (string): Link to required software/library
 
         """
 
-        self.software_requirements.append(
-            SoftwareRequirements(
-                name=name, url=url
-            )
-        )
-
+        self.software_requirements.append(SoftwareRequirements(name=name, url=url))
 
     def add_software_suggestions(
         self,
@@ -233,14 +227,10 @@ class CodeMeta(DataverseBase):
         """Function used to add an instance of SoftwareSuggestions to the metadatablock.
 
         Args:
-        
+
             name (string): Name or title of the optional software/library
             url (string): Link to optional software/library
 
         """
 
-        self.software_suggestions.append(
-            SoftwareSuggestions(
-                name=name, url=url
-            )
-        )
+        self.software_suggestions.append(SoftwareSuggestions(name=name, url=url))

--- a/pyDaRUS/metadatablocks/engMeta.py
+++ b/pyDaRUS/metadatablocks/engMeta.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional, Union
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -586,7 +586,6 @@ class EngMeta(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'engMeta'
 
-
     def add_boundary_conditions(
         self,
         flows: Optional[str] = None,
@@ -595,18 +594,15 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of BoundaryConditions to the metadatablock.
 
         Args:
-        
+
             flows (string): List of in- and outflows describing this boundary condition (detailed information about flows should be given under Flows).
             parameters (string): List of all parameter names relevant for this boundary condition (detailed information about parameters should be given under Boundary Parameters.
 
         """
 
         self.boundary_conditions.append(
-            BoundaryConditions(
-                flows=flows, parameters=parameters
-            )
+            BoundaryConditions(flows=flows, parameters=parameters)
         )
-
 
     def add_boundary_parameters(
         self,
@@ -618,7 +614,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of BoundaryParameters to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the parameter.
             symbol (string): The symbol used to describe this parameter.
             unit (string): The unit or scale of this parameter.
@@ -627,11 +623,8 @@ class EngMeta(DataverseBase):
         """
 
         self.boundary_parameters.append(
-            BoundaryParameters(
-                name=name, symbol=symbol, unit=unit, value=value
-            )
+            BoundaryParameters(name=name, symbol=symbol, unit=unit, value=value)
         )
-
 
     def add_controlled_variables(
         self,
@@ -646,7 +639,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of ControlledVariables to the metadatablock.
 
         Args:
-        
+
             name (string): Name of this variable.
             symbol (string): The symbol used to describe this variable.
             unit (string): The unit or scale of this variable.
@@ -659,10 +652,15 @@ class EngMeta(DataverseBase):
 
         self.controlled_variables.append(
             ControlledVariables(
-                name=name, symbol=symbol, unit=unit, value=value, minimum_value=minimum_value, maximum_value=maximum_value, textual_value=textual_value
+                name=name,
+                symbol=symbol,
+                unit=unit,
+                value=value,
+                minimum_value=minimum_value,
+                maximum_value=maximum_value,
+                textual_value=textual_value,
             )
         )
-
 
     def add_flows(
         self,
@@ -675,7 +673,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of Flows to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the flow.
             components (string): List of system component names this flow belongs to.
             shape (string): Shape of the flow.
@@ -686,10 +684,13 @@ class EngMeta(DataverseBase):
 
         self.flows.append(
             Flows(
-                name=name, components=components, shape=shape, size=size, position=position
+                name=name,
+                components=components,
+                shape=shape,
+                size=size,
+                position=position,
             )
         )
-
 
     def add_force_field(
         self,
@@ -699,18 +700,13 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of ForceField to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the force field.
             parameters (string): List of all parameter names relevant for this force field (detailed information about parameters should be given under Force Field Parameters entry).
 
         """
 
-        self.force_field.append(
-            ForceField(
-                name=name, parameters=parameters
-            )
-        )
-
+        self.force_field.append(ForceField(name=name, parameters=parameters))
 
     def add_force_field_parameters(
         self,
@@ -722,7 +718,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of ForceFieldParameters to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the parameter.
             symbol (string): The symbol used to describe this parameter.
             unit (string): The unit or scale of this parameter.
@@ -731,11 +727,8 @@ class EngMeta(DataverseBase):
         """
 
         self.force_field_parameters.append(
-            ForceFieldParameters(
-                name=name, symbol=symbol, unit=unit, value=value
-            )
+            ForceFieldParameters(name=name, symbol=symbol, unit=unit, value=value)
         )
-
 
     def add_measured_variables(
         self,
@@ -751,7 +744,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of MeasuredVariables to the metadatablock.
 
         Args:
-        
+
             name (string): Name of this variable.
             symbol (string): The symbol used to describe this variable.
             unit (string): The unit or scale of this variable.
@@ -765,10 +758,16 @@ class EngMeta(DataverseBase):
 
         self.measured_variables.append(
             MeasuredVariables(
-                name=name, symbol=symbol, unit=unit, error=error, error_description=error_description, minimum_value=minimum_value, maximum_value=maximum_value, textual_value=textual_value
+                name=name,
+                symbol=symbol,
+                unit=unit,
+                error=error,
+                error_description=error_description,
+                minimum_value=minimum_value,
+                maximum_value=maximum_value,
+                textual_value=textual_value,
             )
         )
-
 
     def add_spatial_resolution(
         self,
@@ -786,7 +785,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of SpatialResolution to the metadatablock.
 
         Args:
-        
+
             number_of_cells (integer): The number of 2D spatial cells.
             number_of_blocks (integer): The number of 3D spatial blocks.
             number_of_points_x (integer): The number of points in x-direction.
@@ -802,10 +801,18 @@ class EngMeta(DataverseBase):
 
         self.spatial_resolution.append(
             SpatialResolution(
-                number_of_cells=number_of_cells, number_of_blocks=number_of_blocks, number_of_points_x=number_of_points_x, number_of_points_y=number_of_points_y, number_of_points_z=number_of_points_z, interval_x=interval_x, interval_y=interval_y, interval_z=interval_z, unit=unit, scaling_formular=scaling_formular
+                number_of_cells=number_of_cells,
+                number_of_blocks=number_of_blocks,
+                number_of_points_x=number_of_points_x,
+                number_of_points_y=number_of_points_y,
+                number_of_points_z=number_of_points_z,
+                interval_x=interval_x,
+                interval_y=interval_y,
+                interval_z=interval_z,
+                unit=unit,
+                scaling_formular=scaling_formular,
             )
         )
-
 
     def add_system_or_phase_components(
         self,
@@ -822,7 +829,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of SystemOrPhaseComponents to the metadatablock.
 
         Args:
-        
+
             id (integer): Unique number that can be referred to in the metadata. Use if Name is not unique.
             name (string): Name of this component.
             description (string): Description of the component.
@@ -837,10 +844,17 @@ class EngMeta(DataverseBase):
 
         self.system_or_phase_components.append(
             SystemOrPhaseComponents(
-                id=id, name=name, description=description, inchicode=inchicode, smilescode=smilescode, iupac_name=iupac_name, quantity=quantity, unit=unit, force_field=force_field
+                id=id,
+                name=name,
+                description=description,
+                inchicode=inchicode,
+                smilescode=smilescode,
+                iupac_name=iupac_name,
+                quantity=quantity,
+                unit=unit,
+                force_field=force_field,
             )
         )
-
 
     def add_system_parameters(
         self,
@@ -853,7 +867,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of SystemParameters to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the parameter.
             symbol (string): The symbol used to describe this parameter.
             unit (string): The unit or scale of this parameter.
@@ -864,10 +878,13 @@ class EngMeta(DataverseBase):
 
         self.system_parameters.append(
             SystemParameters(
-                name=name, symbol=symbol, unit=unit, value=value, textual_value=textual_value
+                name=name,
+                symbol=symbol,
+                unit=unit,
+                value=value,
+                textual_value=textual_value,
             )
         )
-
 
     def add_system_phases(
         self,
@@ -877,18 +894,13 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of SystemPhases to the metadatablock.
 
         Args:
-        
+
             name (string): Name of a phase.
             components (string): List of all component names for this phase (detailed information about components should be given under System Components).
 
         """
 
-        self.system_phases.append(
-            SystemPhases(
-                name=name, components=components
-            )
-        )
-
+        self.system_phases.append(SystemPhases(name=name, components=components))
 
     def add_temporal_resolution(
         self,
@@ -900,7 +912,7 @@ class EngMeta(DataverseBase):
         """Function used to add an instance of TemporalResolution to the metadatablock.
 
         Args:
-        
+
             points (string): List of time points that describe the temporal resolution (if it can not be specified otherwise).
             number_of_time_steps (integer): The number of time points (with equidistant distance).
             interval (number): Distance between two time points.
@@ -910,6 +922,9 @@ class EngMeta(DataverseBase):
 
         self.temporal_resolution.append(
             TemporalResolution(
-                points=points, number_of_time_steps=number_of_time_steps, interval=interval, unit=unit
+                points=points,
+                number_of_time_steps=number_of_time_steps,
+                interval=interval,
+                unit=unit,
             )
         )

--- a/pyDaRUS/metadatablocks/enzymeML.py
+++ b/pyDaRUS/metadatablocks/enzymeML.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -398,7 +398,6 @@ class EnzymeMl(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'enzymeML'
 
-
     def add_kinetic_law(
         self,
         name: Optional[str] = None,
@@ -408,7 +407,7 @@ class EnzymeMl(DataverseBase):
         """Function used to add an instance of KineticLaw to the metadatablock.
 
         Args:
-        
+
             name (string): Specifies the conventional name of the kinetic law that has been used. For instance 'Reversible Michaelis-Menten'.
             reaction_reference (string): Specifies the reaction that has beeen modeled by the given kinetic law.
             kinetic_model (string): Specifies the mathematical equation of the given kinetic law. For variables that reference entities that are part of this EnzymeML document, please use the given identifier. Parameters will be defined in another field and are referenced by their conventional names. For instance, the following equation denotes a valid kinetic model  'vmax  * s1 / ( km + s1 )'.
@@ -417,10 +416,11 @@ class EnzymeMl(DataverseBase):
 
         self.kinetic_law.append(
             KineticLaw(
-                name=name, reaction_reference=reaction_reference, kinetic_model=kinetic_model
+                name=name,
+                reaction_reference=reaction_reference,
+                kinetic_model=kinetic_model,
             )
         )
-
 
     def add_kinetic_parameters(
         self,
@@ -432,7 +432,7 @@ class EnzymeMl(DataverseBase):
         """Function used to add an instance of KineticParameters to the metadatablock.
 
         Args:
-        
+
             name (string): Specifies the conventional name of the kinetic paramter that has been estimated. For instance, 'vmax' is a valid name for a parameter. Please note, that for unique identification the SBO Term should be included.
             value (number): Specifies the numerical value of the estimated kinetic parameter.
             unit (string): Specifies the SI unit of the estimated kinetic parameter.
@@ -441,11 +441,8 @@ class EnzymeMl(DataverseBase):
         """
 
         self.kinetic_parameters.append(
-            KineticParameters(
-                name=name, value=value, unit=unit, sbo_term=sbo_term
-            )
+            KineticParameters(name=name, value=value, unit=unit, sbo_term=sbo_term)
         )
-
 
     def add_proteins(
         self,
@@ -464,7 +461,7 @@ class EnzymeMl(DataverseBase):
         """Function used to add an instance of Proteins to the metadatablock.
 
         Args:
-        
+
             identifier (string): Specifies the internal identifier of the protein. Please follow the convention of denote a protein entity by a 'p' followed by an integer. For instance, 'p1' is a valid ID.
             name (string): Specifies the convential name of the protein. Please note that this field on purpose can not be unique since protein/enzyme names vary in between fields. Use the amino acid sequence, UniProtID and/or EC number for a unique identification.
             vessel_reference (string): Specifies the name of the vessel in which the protein was given. If the protein was part of multiple reactions carried out in different vessel, please separated these via semicolon ';'.
@@ -481,10 +478,19 @@ class EnzymeMl(DataverseBase):
 
         self.proteins.append(
             Proteins(
-                identifier=identifier, name=name, vessel_reference=vessel_reference, initial_concentration=initial_concentration, unit=unit, constant=constant, sequence=sequence, organism=organism, uniprotid=uniprotid, ecnumber=ecnumber, sbo_term=sbo_term
+                identifier=identifier,
+                name=name,
+                vessel_reference=vessel_reference,
+                initial_concentration=initial_concentration,
+                unit=unit,
+                constant=constant,
+                sequence=sequence,
+                organism=organism,
+                uniprotid=uniprotid,
+                ecnumber=ecnumber,
+                sbo_term=sbo_term,
             )
         )
-
 
     def add_reactants(
         self,
@@ -501,7 +507,7 @@ class EnzymeMl(DataverseBase):
         """Function used to add an instance of Reactants to the metadatablock.
 
         Args:
-        
+
             identifier (string): Specifies the internal identifier of the reactant. Please follow the convention of denote a reactant entity by an 's' followed by an integer. For instance, 's1' is a valid ID.
             name (string): Specifies the conventional or systematic name of the given reactant. Please note that this field on purpose can not be unique since molecule names vary in between fields. Please use either the InChI or SMILES code for a unique identification.
             vessel_reference (string): Specifies the vessel in which the reactant was given. If the reactant was part of multiple reactions carried out in different vessel, please separated these via semicolon ';'.
@@ -516,10 +522,17 @@ class EnzymeMl(DataverseBase):
 
         self.reactants.append(
             Reactants(
-                identifier=identifier, name=name, vessel_reference=vessel_reference, initial_concentration=initial_concentration, unit=unit, constant=constant, inchicode=inchicode, smilescode=smilescode, sbo_term=sbo_term
+                identifier=identifier,
+                name=name,
+                vessel_reference=vessel_reference,
+                initial_concentration=initial_concentration,
+                unit=unit,
+                constant=constant,
+                inchicode=inchicode,
+                smilescode=smilescode,
+                sbo_term=sbo_term,
             )
         )
-
 
     def add_reactions(
         self,
@@ -535,7 +548,7 @@ class EnzymeMl(DataverseBase):
         """Function used to add an instance of Reactions to the metadatablock.
 
         Args:
-        
+
             name (string): Specifies the conventional name of the reaction such as 'Alcohol dehydrogenation'. Please note, that this field on purpose can not be uniqe, since names vary in between fields and newly acquired reactions might not have a conventional name yet.
             temperature_value (number): Specifies the temperature value at which the experiment was executed.
             temperature_unit (Enum): Specifies the corresponding SI unit to the temperature value.
@@ -543,16 +556,22 @@ class EnzymeMl(DataverseBase):
             educts (string): Specifies the participating reactants/proteins which serve as educts. If multiple educts have been used, separate each of them via semicolon ';'.
             products (string): Specifies the participating reactants/proteins which serve as products. If multiple products have been used, separate each of them via semicolon ';'.
             modifiers (string): Specifies the participating reactants/proteins which serve as modifiers. For instance catalysing proteins should be entered as modifiers, which is the same for activators/inhibitors. If multiple modifiers have been used, separate each of them via semicolon ';'.
-            equation (string): Specifies the reaction equation by separating educts and products via '->', while denoting multiple educts/products with a plusign and stoichiometries by 'Y Molecule'. For instance the following describes an alcohol dehydrogenation '1 Ethanol + 1 NAD+ -> 1 Acetaldehyde + 1 NADH + 1 H+'. 
+            equation (string): Specifies the reaction equation by separating educts and products via '->', while denoting multiple educts/products with a plusign and stoichiometries by 'Y Molecule'. For instance the following describes an alcohol dehydrogenation '1 Ethanol + 1 NAD+ -> 1 Acetaldehyde + 1 NADH + 1 H+'.
 
         """
 
         self.reactions.append(
             Reactions(
-                name=name, temperature_value=temperature_value, temperature_unit=temperature_unit, ph_value=ph_value, educts=educts, products=products, modifiers=modifiers, equation=equation
+                name=name,
+                temperature_value=temperature_value,
+                temperature_unit=temperature_unit,
+                ph_value=ph_value,
+                educts=educts,
+                products=products,
+                modifiers=modifiers,
+                equation=equation,
             )
         )
-
 
     def add_vessels(
         self,
@@ -564,7 +583,7 @@ class EnzymeMl(DataverseBase):
         """Function used to add an instance of Vessels to the metadatablock.
 
         Args:
-        
+
             name (string): Specifies the exact production name of the vessel shoudl be given here (e.g. Eppendorf Tube)
             size (number): Specifies the volume value of the given vessel (e.g. '1')
             unit (Enum): Specifies the SI unit corresponding to the given vessel size value (e.g. 'mL')
@@ -572,8 +591,4 @@ class EnzymeMl(DataverseBase):
 
         """
 
-        self.vessels.append(
-            Vessels(
-                name=name, size=size, unit=unit, constant=constant
-            )
-        )
+        self.vessels.append(Vessels(name=name, size=size, unit=unit, constant=constant))

--- a/pyDaRUS/metadatablocks/geospatial.py
+++ b/pyDaRUS/metadatablocks/geospatial.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -361,7 +361,6 @@ class Geospatial(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'geospatial'
 
-
     def add_geographic_bounding_box(
         self,
         west_longitude: Optional[str] = None,
@@ -372,7 +371,7 @@ class Geospatial(DataverseBase):
         """Function used to add an instance of GeographicBoundingBox to the metadatablock.
 
         Args:
-        
+
             west_longitude (string): Westernmost coordinate delimiting the geographic extent of the Dataset. A valid range of values,  expressed in decimal degrees, is -180,0 <= West  Bounding Longitude Value <= 180,0.
             east_longitude (string): Easternmost coordinate delimiting the geographic extent of the Dataset. A valid range of values,  expressed in decimal degrees, is -180,0 <= East Bounding Longitude Value <= 180,0.
             north_latitude (string): Northernmost coordinate delimiting the geographic extent of the Dataset. A valid range of values,  expressed in decimal degrees, is -90,0 <= North Bounding Latitude Value <= 90,0.
@@ -382,10 +381,12 @@ class Geospatial(DataverseBase):
 
         self.geographic_bounding_box.append(
             GeographicBoundingBox(
-                west_longitude=west_longitude, east_longitude=east_longitude, north_latitude=north_latitude, south_latitude=south_latitude
+                west_longitude=west_longitude,
+                east_longitude=east_longitude,
+                north_latitude=north_latitude,
+                south_latitude=south_latitude,
             )
         )
-
 
     def add_geographic_coverage(
         self,
@@ -397,7 +398,7 @@ class Geospatial(DataverseBase):
         """Function used to add an instance of GeographicCoverage to the metadatablock.
 
         Args:
-        
+
             country___nation (Enum): The country or nation that the Dataset is about.
             state___province (string): The state or province that the Dataset is about. Use GeoNames for correct spelling and avoid abbreviations.
             city (string): The name of the city that the Dataset is about. Use GeoNames for correct spelling and avoid abbreviations.
@@ -407,6 +408,9 @@ class Geospatial(DataverseBase):
 
         self.geographic_coverage.append(
             GeographicCoverage(
-                country___nation=country___nation, state___province=state___province, city=city, other=other
+                country___nation=country___nation,
+                state___province=state___province,
+                city=city,
+                other=other,
             )
         )

--- a/pyDaRUS/metadatablocks/journal.py
+++ b/pyDaRUS/metadatablocks/journal.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -91,7 +91,6 @@ class Journal(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'journal'
 
-
     def add_journal_data(
         self,
         volume: Optional[str] = None,
@@ -101,7 +100,7 @@ class Journal(DataverseBase):
         """Function used to add an instance of JournalData to the metadatablock.
 
         Args:
-        
+
             volume (string): The journal volume which this Dataset is associated with (e.g., Volume 4).
             issue (string): The journal issue number which this Dataset is associated with (e.g., Number 2, Autumn).
             publication_date (string): The publication date for this journal volume/issue, which this Dataset is associated with (e.g., 1999).
@@ -109,7 +108,5 @@ class Journal(DataverseBase):
         """
 
         self.journal_data.append(
-            JournalData(
-                volume=volume, issue=issue, publication_date=publication_date
-            )
+            JournalData(volume=volume, issue=issue, publication_date=publication_date)
         )

--- a/pyDaRUS/metadatablocks/privacy.py
+++ b/pyDaRUS/metadatablocks/privacy.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 

--- a/pyDaRUS/metadatablocks/process.py
+++ b/pyDaRUS/metadatablocks/process.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -361,7 +361,6 @@ class Process(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'process'
 
-
     def add_environments(
         self,
         name: Optional[str] = None,
@@ -372,7 +371,7 @@ class Process(DataverseBase):
         """Function used to add an instance of Environments to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the environment.
             compiler_names_and_flags (array): Name and flags of the used compilers.
             number_of_nodes (integer): Number of compute nodes inside a high performance cluster environment.
@@ -382,10 +381,12 @@ class Process(DataverseBase):
 
         self.environments.append(
             Environments(
-                name=name, compiler_names_and_flags=compiler_names_and_flags, number_of_nodes=number_of_nodes, ppn=ppn
+                name=name,
+                compiler_names_and_flags=compiler_names_and_flags,
+                number_of_nodes=number_of_nodes,
+                ppn=ppn,
             )
         )
-
 
     def add_instruments(
         self,
@@ -400,7 +401,7 @@ class Process(DataverseBase):
         """Function used to add an instance of Instruments to the metadatablock.
 
         Args:
-        
+
             name (string): Name of this instrument.
             description (string): Description of the instrument, e.g., what it is used for.
             version (string): The type or version of this instrument.
@@ -413,10 +414,15 @@ class Process(DataverseBase):
 
         self.instruments.append(
             Instruments(
-                name=name, description=description, version=version, part_number=part_number, serial_number=serial_number, software=software, location=location
+                name=name,
+                description=description,
+                version=version,
+                part_number=part_number,
+                serial_number=serial_number,
+                software=software,
+                location=location,
             )
         )
-
 
     def add_method_parameters(
         self,
@@ -429,7 +435,7 @@ class Process(DataverseBase):
         """Function used to add an instance of MethodParameters to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the parameter.
             symbol (string): The symbol used to describe this parameter.
             unit (string): The unit or scale of this parameter.
@@ -440,10 +446,13 @@ class Process(DataverseBase):
 
         self.method_parameters.append(
             MethodParameters(
-                name=name, symbol=symbol, unit=unit, value=value, textual_value=textual_value
+                name=name,
+                symbol=symbol,
+                unit=unit,
+                value=value,
+                textual_value=textual_value,
             )
         )
-
 
     def add_processing_methods(
         self,
@@ -454,7 +463,7 @@ class Process(DataverseBase):
         """Function used to add an instance of ProcessingMethods to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the method as free text.
             description (string): Description of the method as free text
             parameters (string): List of all parameter names relevant for this method (detailed information about parameters should be given under Method Parameters).
@@ -462,11 +471,8 @@ class Process(DataverseBase):
         """
 
         self.processing_methods.append(
-            ProcessingMethods(
-                name=name, description=description, parameters=parameters
-            )
+            ProcessingMethods(name=name, description=description, parameters=parameters)
         )
-
 
     def add_processing_steps(
         self,
@@ -484,7 +490,7 @@ class Process(DataverseBase):
         """Function used to add an instance of ProcessingSteps to the metadatablock.
 
         Args:
-        
+
             id (integer): Used to order the processing steps.
             type (Enum): Specifies the position in the data life cycle.
             date (string): Date this step has been performed.
@@ -500,10 +506,18 @@ class Process(DataverseBase):
 
         self.processing_steps.append(
             ProcessingSteps(
-                id=id, type=type, date=date, methods=methods, error_method=error_method, software=software, instruments=instruments, environment=environment, input=input, output=output
+                id=id,
+                type=type,
+                date=date,
+                methods=methods,
+                error_method=error_method,
+                software=software,
+                instruments=instruments,
+                environment=environment,
+                input=input,
+                output=output,
             )
         )
-
 
     def add_software(
         self,
@@ -518,7 +532,7 @@ class Process(DataverseBase):
         """Function used to add an instance of Software to the metadatablock.
 
         Args:
-        
+
             name (string): Name of the software.
             version (string): Version of the software.
             id_type (Enum): The type of digital identifier used for this software (e.g., Digital Object Identifier (DOI)).
@@ -531,6 +545,12 @@ class Process(DataverseBase):
 
         self.software.append(
             Software(
-                name=name, version=version, id_type=id_type, id_number=id_number, citation=citation, url=url, license=license
+                name=name,
+                version=version,
+                id_type=id_type,
+                id_number=id_number,
+                citation=citation,
+                url=url,
+                license=license,
             )
         )

--- a/pyDaRUS/metadatablocks/socialscience.py
+++ b/pyDaRUS/metadatablocks/socialscience.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from easyDataverse.core import DataverseBase
+from easyDataverse.base import DataverseBase
 from pydantic import Field
 
 
@@ -201,7 +201,6 @@ class Socialscience(DataverseBase):
     )
     _metadatablock_name: Optional[str] = 'socialscience'
 
-
     def add_notes(
         self,
         type: Optional[str] = None,
@@ -211,19 +210,14 @@ class Socialscience(DataverseBase):
         """Function used to add an instance of Notes to the metadatablock.
 
         Args:
-        
+
             type (string): Type of note.
             subject (string): Note subject.
             text (string): Text for this note.
 
         """
 
-        self.notes.append(
-            Notes(
-                type=type, subject=subject, text=text
-            )
-        )
-
+        self.notes.append(Notes(type=type, subject=subject, text=text))
 
     def add_target_sample_size(
         self,
@@ -233,14 +227,10 @@ class Socialscience(DataverseBase):
         """Function used to add an instance of TargetSampleSize to the metadatablock.
 
         Args:
-        
+
             actual (integer): Actual sample size.
             formula (string): Formula used to determine target sample size.
 
         """
 
-        self.target_sample_size.append(
-            TargetSampleSize(
-                actual=actual, formula=formula
-            )
-        )
+        self.target_sample_size.append(TargetSampleSize(actual=actual, formula=formula))


### PR DESCRIPTION
Included is a fix for the move of the DataverseBase Class from the core to base in easyDataverse, which makes pyDaRUS abort execution. Included is the Traceback that resulted in this fix:

```
Traceback (most recent call last):
  File "/.../sandbox/src/main.py", line 1, in <module>
    from pyDaRUS import Dataset
  File "/.../sandbox/.venv/lib/python3.10/site-packages/pyDaRUS/__init__.py", line 4, in <module>
    from pyDaRUS.metadatablocks import Astrophysics
  File "/.../sandbox/.venv/lib/python3.10/site-packages/pyDaRUS/metadatablocks/__init__.py", line 11, in <module>
    from pyDaRUS.metadatablocks.archive import Archive
  File "/.../sandbox/.venv/lib/python3.10/site-packages/pyDaRUS/metadatablocks/archive.py", line 10, in <module>
    from easyDataverse.core import DataverseBase
ModuleNotFoundError: No module named 'easyDataverse.core'
```